### PR TITLE
fix: set ZIG_LIB_DIR before spawning zls

### DIFF
--- a/zig/zls/zls_runner.zig
+++ b/zig/zls/zls_runner.zig
@@ -108,6 +108,7 @@ fn main_pre_016() !void {
     });
     var child_env_map = try std.process.getEnvMap(allocator);
     defer child_env_map.deinit();
+    try child_env_map.put("ZIG_LIB_DIR", zig_lib_computed_path);
     try child_env_map.put("ZIG_GLOBAL_CACHE_DIR", global_cache_path);
     try child_env_map.put("ZIG_LOCAL_CACHE_DIR", global_cache_path);
 
@@ -187,6 +188,7 @@ fn main_016(init: std.process.Init) !void {
     for (init.environ_map.keys(), init.environ_map.values()) |key, value| {
         try child_env_map.put(key, value);
     }
+    try child_env_map.put("ZIG_LIB_DIR", zig_lib_computed_path);
     try child_env_map.put("ZIG_GLOBAL_CACHE_DIR", global_cache_path);
     try child_env_map.put("ZIG_LOCAL_CACHE_DIR", global_cache_path);
 


### PR DESCRIPTION
When zig is being built from source, the resulting binary may not be materialized as a zig installation, and might not have adjacent lib directory.

This is an issue within zls might call the naked zig binary which will fail in our case until ZIG_LIB_DIR is set.