### PR TITLE
fix(zig_toolchain): avoid depending on coreutils touch in version validation

### DIFF
--- a/zig/private/zig_toolchain.bzl
+++ b/zig/private/zig_toolchain.bzl
@@ -125,7 +125,7 @@ def _validate_zig_version(ctx, *, zig_exe, tools, zig_version):
             '  echo "Zig SDK version mismatch. Expected \'$2\' but got \'$actual_version\'." >&2',
             "  exit 1",
             "fi",
-            'touch "$3"',
+            'printf \'\' > "$3"',
         ]),
         mnemonic = "ZigVersionValidation",
         progress_message = "validate Zig SDK version for toolchain %{label}",


### PR DESCRIPTION
- The version-validation action's shell script ran unqualified and with no declared env/PATH, so it inherits an empty action environment. On systems without an FHS-style /bin:/usr/bin (e.g. NixOS), bash's compiled-in fallback PATH doesn't resolve `touch`, and the action fails with `touch: command not found` even though bash itself was found via an explicit toolchain path.
- Replace `touch` with `printf`, a bash builtin.